### PR TITLE
Make Angular a peer dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ before_script:
   - npm install -g bower
   - bower install
   - npm install -g grunt-cli
+  - npm install angular

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "author": "aleross",
   "license": "MIT",
   "homepage": "https://github.com/aleross/angular-segment-analytics",
-  "dependencies": {
-    "angular": "latest"
+  "peerDependencies": {
+    "angular": "1.x.x"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
Fixes #14 

Make angular a peer dependency vs a normal dependency. To have a copy of angular for the tests, I added the installation of it in the .travis.yml, but I'm open to other suggestions (like adding it to the dev dependencies)!
